### PR TITLE
adjust styling in all forms & improve transaction type handling

### DIFF
--- a/components/FormAddCategory.js
+++ b/components/FormAddCategory.js
@@ -4,12 +4,12 @@ import styled from "styled-components";
 export default function FormAddCategory({ onCancel }) {
   const router = useRouter();
 
-  // Cancel-Button
+  // cancel-button
   function handleCancel() {
-    onCancel(); // zurück zur Frage in AddingPage
+    onCancel(); // zurück zu AddingPage (selection view)
   }
 
-  // Save-Button
+  // save-button
   async function handleSubmit(event) {
     event.preventDefault();
 
@@ -26,10 +26,12 @@ export default function FormAddCategory({ onCancel }) {
       });
 
       if (response.ok) {
-        console.log("ADDING SUCCESSFULL! (category)");
-        router.back(); // nach erfolgreichem Hinzufügen neuer Kategorie zurück zur vorherigen Seite
+        console.log("ADDING SUCCESSFUL! (category)");
+        router.back(); // nach erfolgreichem Hinzufügen neuer category zurück zur vorherigen page
       } else {
-        throw new Error("Failed to add new category");
+        throw new Error(
+          `Failed to add new category (status: ${response.status})`
+        );
       }
     } catch (error) {
       console.error("Error adding new category: ", error);
@@ -45,6 +47,7 @@ export default function FormAddCategory({ onCancel }) {
           <label htmlFor="type" className="label-type">
             Type:
           </label>
+
           <RadioRow>
             <RadioOption>
               <input
@@ -52,7 +55,7 @@ export default function FormAddCategory({ onCancel }) {
                 id="income"
                 name="type"
                 value="Income"
-                required // reicht nur bei der 1. Option für Fehlermeldung
+                required
               />
               <label htmlFor="income">Income</label>
             </RadioOption>

--- a/components/FormAddCategory.js
+++ b/components/FormAddCategory.js
@@ -42,7 +42,9 @@ export default function FormAddCategory({ onCancel }) {
         <h1>Add Category</h1>
 
         <TypeGroup>
-          <label htmlFor="type">Type:</label>
+          <label htmlFor="type" className="label-type">
+            Type:
+          </label>
           <RadioRow>
             <RadioOption>
               <input
@@ -86,23 +88,22 @@ export default function FormAddCategory({ onCancel }) {
 }
 
 const PageWrapper = styled.div`
-  min-height: 100vh; // Wrapper nimmt mind. volle Bildschirmhöhe ein
-  display: flex; // zentriert Inhalt
-  justify-content: center; // form horizontal zentriert
-  align-items: center; // form vertikal zentriert
+  min-height: 100vh; // wrapper mind. wie viewport
   padding: 2rem; // Abstand zum Bildschirmrand
+  display: flex; // wegen Zentrierung von form
+  align-items: center; // form vertikal zentriert
+  justify-content: center; // form horizontal zentriert
 `;
 
 const FormContainer = styled.form`
-  width: 100%; // gesamte verf. Breite von Elterncontainer
-  max-width: 420px;
+  max-width: 300px;
   background-color: var(--button-background-color);
   padding: 1.5rem 2rem 2rem 2rem;
   border-radius: 1.5rem; // abgerundete Ecken
 
-  display: flex; // vertikale Anordnung von form-Inhalt
-  flex-direction: column; // untereinander
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.66);
+  display: flex; // content vertikal
+  flex-direction: column; // content untereinander
+  box-shadow: 0 0 20px rgba(0, 0, 0, 1);
 
   h1 {
     text-align: center;
@@ -114,26 +115,23 @@ const FormContainer = styled.form`
     margin-bottom: 0.5rem; // Abstand zw. label & jeweiligem input
   }
 
-  label:first-child {
-    margin-bottom: 0.8rem;
-
-    // bei Umbruch von Type & RadioRow kein margin-bottom -> TypeGroup margin-bottom zum nächsten Block
-    @media (max-width: 338px) {
-      margin-bottom: 0;
-    }
-  }
-
-  input {
-    cursor: pointer;
-    margin-bottom: 0.8rem; // Abstand zw. Blöcken
+  input[type="text"],
+  input[type="color"] {
     border-radius: 0.5rem; // abgerundete Ecken
     border: 0.07rem solid var(--button-hover-color);
+    height: 1.5rem;
+  }
+
+  input[type="text"] {
+    margin-bottom: 0.8rem; // Abstand zu Color
+
+    // Firefox: wenn Feld angeklickt, kein blauer Rahmen:
+    accent-color: var(--button-hover-color);
   }
 
   input[type="color"] {
-    width: 100%; // auch so breit wie parent
-    margin-bottom: 0; // letztes input-Feld kein Abstand zu ButtonContainer
-    height: 1.5rem;
+    cursor: pointer;
+    width: 100%; // auch so breit wie container
   }
 
   /*********************** Chrome ***********************/
@@ -147,56 +145,72 @@ const FormContainer = styled.form`
   }
 
   /******************************************************/
-
-  // muss unter [type="color"] stehen, es überschreibt sonst  (?!)
-  input[type="text"] {
-    height: 1.5rem;
-    accent-color: var(
-      --button-hover-color
-    ); // Firefox: wenn Feld angeklickt, kein blauer Rahmen
-  }
 `;
 
 const TypeGroup = styled.div`
   display: flex; // Type & RadioRow in einer Reihe
   flex-wrap: wrap; // Umbruch von Type & RadioRow, wenn nicht genug Platz
-  gap: 1rem; // Abstand zw. Type & RadioRow
+  margin-bottom: 1rem; // Abstand zu Name
 
-  // bei Umbruch von Type & RadioRow kleinere gap + margin-bottom zum nächsten Block
-  @media (max-width: 338px) {
-    gap: 0.35rem;
-    margin-bottom: 0.7rem;
+  // *** Abstand zw. Type & RadioRow: ***************************************
+  // margin, nicht margin-right! (im FormContainer haben label margin-bottom)
+  .label-type {
+    margin: 0 1rem 0 0;
+
+    @media (max-width: 338px) {
+      margin: 0 0.75rem 0 0; // kleiner
+    }
+    @media (max-width: 326px) {
+      margin: 0 0.75rem 0.35rem 0; // bei Umbruch auch unten
+    }
+  }
+  // ************************************************************************
+
+  @media (max-width: 326px) {
+    margin-bottom: 0.8rem; // Abstand zu Category bei Umbruch von Type & Radiorow
   }
 `;
 
 const RadioRow = styled.div`
   display: flex; // beide RadioOptions nebeneinander
-  gap: 1rem; // Abstand zw. RadioOptions
 
-  // bei Umbruch von Type & RadioRow kleinere gap
+  // *** Abstand zw. RadioOptions: *******************************************
+  gap: 1rem;
+
   @media (max-width: 338px) {
-    gap: 0.35rem;
+    gap: 0.5rem; // kleiner
   }
+  @media (max-width: 326px) {
+    gap: 1rem; // bei Umbruch von Type & Radiorow wieder normal
+  }
+  // **************************************************************************
 `;
 
 const RadioOption = styled.div`
   input {
-    accent-color: var(--button-hover-color);
+    cursor: pointer;
+    margin-right: 0.35rem; // Abstand zw. radio & label
+  }
+
+  input#income {
+    accent-color: var(--income-color);
+  }
+  input#expense {
+    accent-color: var(--expense-color);
   }
 
   label {
+    cursor: pointer;
     font-size: 0.9rem;
     font-weight: normal;
-    margin-left: 0.35rem; // Abstand zw. radio & label
   }
 `;
 
 const ButtonContainer = styled.div`
-  margin-top: 2rem; // Abstand zum letzten input-Feld
-  display: flex;
+  margin-top: 2rem; // Abstand zum letzten input
+  display: flex; // wegen Zentrierung
   justify-content: center; // buttons zentriert
   gap: 1rem; // Abstand zw. buttons
-  flex-wrap: wrap; // Umbruch; buttons untereinander
 
   button {
     border: none;
@@ -204,10 +218,11 @@ const ButtonContainer = styled.div`
     min-width: 70px;
     min-height: 30px;
     cursor: pointer;
+    font-weight: bold;
+    background-color: var(--secondary-text-color);
 
     &:hover {
       transform: scale(1.07);
-      font-weight: bold;
     }
   }
 `;

--- a/components/FormAddTransaction.js
+++ b/components/FormAddTransaction.js
@@ -63,6 +63,10 @@ export default function FormAddTransaction({ onCancel }) {
 
   // *******************************************************************************************************************************************
 
+  // verhindert Laufzeitfehler bis categories über SWR abgerufen werden:
+  if (error) return <h3>Failed to load data</h3>;
+  if (!categories) return <h3>Loading ...</h3>;
+
   // Cancel-Button
   function handleCancel() {
     if (onCancel)

--- a/components/FormAddTransaction.js
+++ b/components/FormAddTransaction.js
@@ -52,7 +52,9 @@ export default function FormAddTransaction({ onCancel }) {
         <h1>Add Transaction</h1>
 
         <TypeGroup>
-          <label htmlFor="type">Type:</label>
+          <label htmlFor="type" className="label-type">
+            Type:
+          </label>
 
           <RadioRow>
             <RadioOption>
@@ -131,23 +133,22 @@ export default function FormAddTransaction({ onCancel }) {
 }
 
 const PageWrapper = styled.div`
-  min-height: 100vh; // Wrapper nimmt mind. volle Bildschirmhöhe ein
-  display: flex; // zentriert Inhalt
-  justify-content: center; // form horizontal zentriert
-  align-items: center; // form vertikal zentriert
+  min-height: 100vh; // wrapper mind. wie viewport
   padding: 2rem; // Abstand zum Bildschirmrand
+  display: flex; // wegen Zentrierung von form
+  align-items: center; // form vertikal zentriert
+  justify-content: center; // form horizontal zentriert
 `;
 
 const FormContainer = styled.form`
-  width: 100%; // gesamte verf. Breite von Elterncontainer
-  max-width: 420px;
+  max-width: 300px;
   background-color: var(--button-background-color);
   padding: 1.5rem 2rem 2rem 2rem;
   border-radius: 1.5rem; // abgerundete Ecken
 
-  display: flex; // vertikale Anordnung von form-Inhalt
-  flex-direction: column; // untereinander
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.66);
+  display: flex; // content vertikal
+  flex-direction: column; // content untereinander
+  box-shadow: 0 0 20px rgba(0, 0, 0, 1);
 
   h1 {
     text-align: center;
@@ -159,34 +160,21 @@ const FormContainer = styled.form`
     margin-bottom: 0.5rem; // Abstand zw. label & jeweiligem input
   }
 
-  label:first-child {
-    margin-bottom: 0.8rem;
-
-    // bei Umbruch von Type & RadioRow kein margin-bottom -> TypeGroup margin-bottom zum nächsten Block
-    @media (max-width: 338px) {
-      margin-bottom: 0;
-    }
-  }
-
-  input,
-  select {
+  select,
+  input[type="text"],
+  input[type="number"],
+  input[type="date"] {
     cursor: pointer;
     margin-bottom: 0.8rem; // Abstand zw. Blöcken
     border-radius: 0.5rem; // abgerundete Ecken
     border: 0.07rem solid var(--button-hover-color);
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  select {
     height: 1.5rem;
-    accent-color: var(
-      --button-hover-color
-    ); // Firefox: wenn Feld angeklickt, kein blauer Rahmen
+
+    // Firefox: wenn Feld angeklickt, kein blauer Rahmen:
+    accent-color: var(--button-hover-color);
   }
 
-  input:last-of-type {
+  input[type="date"] {
     margin-bottom: 0; // letztes input-Feld kein Abstand zu ButtonContainer
   }
 `;
@@ -194,43 +182,67 @@ const FormContainer = styled.form`
 const TypeGroup = styled.div`
   display: flex; // Type & RadioRow in einer Reihe
   flex-wrap: wrap; // Umbruch von Type & RadioRow, wenn nicht genug Platz
-  gap: 1rem; // Abstand zw. Type & RadioRow
+  margin-bottom: 1rem; // Abstand zu Category
 
-  // bei Umbruch von Type & RadioRow kleinere gap + margin-bottom zum nächsten Block
-  @media (max-width: 338px) {
-    gap: 0.35rem;
-    margin-bottom: 0.7rem;
+  // *** Abstand zw. Type & RadioRow: ***************************************
+  // margin, nicht margin-right! (im FormContainer haben label margin-bottom)
+  .label-type {
+    margin: 0 1rem 0 0;
+
+    @media (max-width: 338px) {
+      margin: 0 0.75rem 0 0; // kleiner
+    }
+    @media (max-width: 326px) {
+      margin: 0 0.75rem 0.35rem 0; // bei Umbruch auch unten
+    }
+  }
+  // ************************************************************************
+
+  @media (max-width: 326px) {
+    margin-bottom: 0.8rem; // Abstand zu Category bei Umbruch von Type & Radiorow
   }
 `;
 
 const RadioRow = styled.div`
   display: flex; // beide RadioOptions nebeneinander
-  gap: 1rem; // Abstand zw. RadioOptions
 
-  // bei Umbruch von Type & RadioRow kleinere gap
+  // *** Abstand zw. RadioOptions: *******************************************
+  gap: 1rem;
+
   @media (max-width: 338px) {
-    gap: 0.35rem;
+    gap: 0.5rem; // kleiner
   }
+  @media (max-width: 326px) {
+    gap: 1rem; // bei Umbruch von Type & Radiorow wieder normal
+  }
+  // **************************************************************************
 `;
 
 const RadioOption = styled.div`
   input {
-    accent-color: var(--button-hover-color);
+    cursor: pointer;
+    margin-right: 0.35rem; // Abstand zw. radio & label
+  }
+
+  #income {
+    accent-color: var(--income-color);
+  }
+  #expense {
+    accent-color: var(--expense-color);
   }
 
   label {
+    cursor: pointer;
     font-size: 0.9rem;
     font-weight: normal;
-    margin-left: 0.35rem; // Abstand zw. radio & label
   }
 `;
 
 const ButtonContainer = styled.div`
-  margin-top: 2rem; // Abstand zum letzten input-Feld
-  display: flex;
+  margin-top: 2rem; // Abstand zum letzten input
+  display: flex; // wegen Zentrierung
   justify-content: center; // buttons zentriert
   gap: 1rem; // Abstand zw. buttons
-  flex-wrap: wrap; // Umbruch; buttons untereinander
 
   button {
     border: none;
@@ -238,10 +250,11 @@ const ButtonContainer = styled.div`
     min-width: 70px;
     min-height: 30px;
     cursor: pointer;
+    font-weight: bold;
+    background-color: var(--secondary-text-color);
 
     &:hover {
       transform: scale(1.07);
-      font-weight: bold;
     }
   }
 `;

--- a/components/FormEditCategory.js
+++ b/components/FormEditCategory.js
@@ -84,7 +84,10 @@ export default function FormEditCategory() {
         <h1>Edit Category</h1>
 
         <TypeGroup>
-          <label htmlFor="type">Type:</label>
+          <label htmlFor="type" className="label-type">
+            Type:
+          </label>
+
           <RadioRow>
             <RadioOption>
               <input
@@ -162,23 +165,22 @@ export default function FormEditCategory() {
 }
 
 const PageWrapper = styled.div`
-  min-height: 100vh; // Wrapper nimmt mind. volle Bildschirmhöhe ein
-  display: flex; // zentriert Inhalt
-  justify-content: center; // form horizontal zentriert
-  align-items: center; // form vertikal zentriert
   padding: 2rem; // Abstand zum Bildschirmrand
+  min-height: 100vh; // wrapper mind. wie viewport
+  display: flex; // wegen Zentrierung von form
+  align-items: center; // form vertikal zentriert
+  justify-content: center; // form horizontal zentriert
 `;
 
 const FormContainer = styled.form`
-  width: 100%; // gesamte verf. Breite von Elterncontainer
-  max-width: 420px;
+  max-width: 300px;
   background-color: var(--button-background-color);
   padding: 1.5rem 2rem 2rem 2rem;
   border-radius: 1.5rem; // abgerundete Ecken
 
-  display: flex; // vertikale Anordnung von form-Inhalt
-  flex-direction: column; // untereinander
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.66);
+  display: flex; // content vertikal
+  flex-direction: column; // content untereinander
+  box-shadow: 0 0 20px rgba(0, 0, 0, 1);
 
   h1 {
     text-align: center;
@@ -190,88 +192,94 @@ const FormContainer = styled.form`
     margin-bottom: 0.5rem; // Abstand zw. label & jeweiligem input
   }
 
-  label:first-child {
-    margin-bottom: 0.8rem;
-
-    // bei Umbruch von Type & RadioRow kein margin-bottom -> TypeGroup margin-bottom zum nächsten Block
-    @media (max-width: 338px) {
-      margin-bottom: 0;
-    }
-  }
-
-  input {
-    cursor: pointer;
-    margin-bottom: 0.8rem; // Abstand zw. Blöcken
+  input[type="text"],
+  input[type="color"] {
     border-radius: 0.5rem; // abgerundete Ecken
     border: 0.07rem solid var(--button-hover-color);
+    height: 1.5rem;
+  }
+
+  input[type="text"] {
+    margin-bottom: 0.8rem; // Abstand zu Color
+
+    // Firefox: wenn Feld angeklickt, kein blauer Rahmen:
+    accent-color: var(--button-hover-color);
   }
 
   input[type="color"] {
-    width: 100%; // auch so breit wie parent
-    margin-bottom: 0; // letztes input-Feld kein Abstand zu ButtonContainer
-    height: 1.5rem;
+    cursor: pointer;
+    width: 100%; // auch so breit wie container
   }
 
   /*********************** Chrome ***********************/
-
   input[type="color"]::-webkit-color-swatch-wrapper {
     padding: 0; // hässliches weißes padding weg
   }
-
   input[type="color"]::-webkit-color-swatch {
     border: none; // grauer innerer Rahmen weg
   }
-
   /******************************************************/
-
-  // muss unter [type="color"] stehen, es überschreibt sonst  (?!)
-  input[type="text"] {
-    height: 1.5rem;
-    accent-color: var(
-      --button-hover-color
-    ); // Firefox: wenn Feld angeklickt, kein blauer Rahmen
-  }
 `;
 
 const TypeGroup = styled.div`
   display: flex; // Type & RadioRow in einer Reihe
   flex-wrap: wrap; // Umbruch von Type & RadioRow, wenn nicht genug Platz
-  gap: 1rem; // Abstand zw. Type & RadioRow
+  margin-bottom: 1rem; // Abstand zu Name
 
-  // bei Umbruch von Type & RadioRow kleinere gap + margin-bottom zum nächsten Block
-  @media (max-width: 338px) {
-    gap: 0.35rem;
-    margin-bottom: 0.7rem;
+  // *** Abstand zw. Type & RadioRow: ***************************************
+  // margin, nicht margin-right! (im FormContainer haben label margin-bottom)
+  .label-type {
+    margin: 0 1rem 0 0;
+
+    @media (max-width: 338px) {
+      margin: 0 0.75rem 0 0; // kleiner
+    }
+    @media (max-width: 326px) {
+      margin: 0 0.75rem 0.35rem 0; // bei Umbruch auch unten
+    }
+  }
+  // ************************************************************************
+
+  @media (max-width: 326px) {
+    margin-bottom: 0.8rem; // Abstand zu Category bei Umbruch von Type & Radiorow
   }
 `;
 
 const RadioRow = styled.div`
   display: flex; // beide RadioOptions nebeneinander
-  gap: 1rem; // Abstand zw. RadioOptions
 
-  // bei Umbruch von Type & RadioRow kleinere gap
+  // *** Abstand zw. RadioOptions: *******************************************
+  gap: 1rem;
+
   @media (max-width: 338px) {
-    gap: 0.35rem;
+    gap: 0.5rem; // kleiner
   }
+  @media (max-width: 326px) {
+    gap: 1rem; // bei Umbruch von Type & Radiorow wieder normal
+  }
+  // **************************************************************************
 `;
 
 const RadioOption = styled.div`
-  input {
-    accent-color: var(--button-hover-color);
+  input#income {
+    accent-color: var(--income-color);
+  }
+  input#expense {
+    accent-color: var(--expense-color);
   }
 
   label {
+    margin-left: 0.35rem; // Abstand zw. radio & label
     font-size: 0.9rem;
     font-weight: normal;
-    margin-left: 0.35rem; // Abstand zw. radio & label
   }
 `;
 
 const ButtonContainer = styled.div`
-  margin-top: 2rem; // Abstand zum letzten input-Feld
-  display: flex;
+  margin-top: 2rem; // Abstand zum letzten input
+  display: flex; // wegen Zentrierung
   justify-content: center; // buttons zentriert
-  gap: 1rem; // Abstand zw. buttons
+  gap: 0.8rem; // Abstand zw. buttons
   flex-wrap: wrap; // Umbruch; buttons untereinander
 
   button {
@@ -280,10 +288,11 @@ const ButtonContainer = styled.div`
     min-width: 70px;
     min-height: 30px;
     cursor: pointer;
+    font-weight: bold;
+    background-color: var(--secondary-text-color);
 
     &:hover {
       transform: scale(1.07);
-      font-weight: bold;
     }
   }
 `;

--- a/components/FormEditTransaction.js
+++ b/components/FormEditTransaction.js
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { useRouter } from "next/router";
-import styled from "styled-components";
 import { useEffect, useState } from "react"; // effect + state: category-Änderung -> type-Änderung // state: ConfirmModal open/!open
+import styled from "styled-components";
 import ConfirmModal from "./ConfirmModal";
 
 export default function FormEditTransaction() {
@@ -12,13 +12,13 @@ export default function FormEditTransaction() {
 
   const { data: transaction, error: errorTransaction } = useSWR(
     id ? `/api/transactions/${id}` : null
-  ); // transaction abrufen
+  );
   const { data: categories, error: errorCategories } =
-    useSWR("/api/categories"); // für Dropdown, damit Kategorien zur Auswahl abgerufen werden
+    useSWR("/api/categories");
 
-  /*** [ type-Änderung ] *************************************************************************************************
+  /*** [ type-Änderung ] *****************************************************************************
     -> manuell: nicht möglich
-    -> dropdown: category-Änderung -> ggf. type-Änderung (transaction-type = category-type)                             */
+    -> dropdown: category-Änderung -> type-Änderung (transaction-type = category-type)         */
 
   // state für aktuelle category(-ID) im dropdown
   const [currentCategoryId, setCurrentCategoryId] = useState("");
@@ -29,24 +29,24 @@ export default function FormEditTransaction() {
     setCurrentCategoryId(transaction.category?._id || "");
   }, [transaction]);
 
-  // um type immer aus aktuell gewählter category abzuleiten
-  const selectedCategory = categories.find(
-    (category) => category._id === currentCategoryId
-  );
-
-  const typeFromSelectedCategory = selectedCategory?.type || "";
-
-  // *******************************************************************************************************************
-
+  // guards: um Laufzeitfehler zu verhindern, bis Daten abgerufen werden
   if (errorTransaction || errorCategories) return <h3>Failed to load data</h3>;
-  if (!transaction || !categories) return <h3>Loading...</h3>;
+  if (!transaction || !categories || !currentCategoryId)
+    return <h3>Loading ...</h3>;
 
-  // Cancel-Button
+  // um type immer aus aktuell gewählter category abzuleiten
+  const currentType = categories.find(
+    (category) => category._id === currentCategoryId
+  )?.type;
+
+  // *************************************************************************************************
+
+  // cancel-button: zurück zur vorherigen Seite
   function handleCancel() {
-    router.back(); // zurück zur vorherigen Seite (nochmal überdenken, ob er nicht lieber Formular clearen soll & zustätzl. X-Button dafür implemetieren)
+    router.back();
   }
 
-  // Save-Button
+  // save-button
   async function handleSubmit(event) {
     event.preventDefault();
 
@@ -64,37 +64,41 @@ export default function FormEditTransaction() {
 
       if (response.ok) {
         console.log("UPDATING SUCCESSFUL! (transaction)");
-        router.back(); // nach erfolgreichem Updaten der Transaktion zurück zur vorherigen Seite
+        router.back(); // zurück zur vorherigen page
       } else {
-        throw new Error("Failed to update transaction");
+        throw new Error(
+          `Failed to update transaction (status: ${response.status})`
+        );
       }
     } catch (error) {
       console.error("Error updating transaction: ", error);
     }
   }
 
-  // 1. delete button: öffnet ConfirmModal, statt direkt Löschung
-  async function handleDelete() {
+  // 1. delete-button: öffnet ConfirmModal
+  function handleDelete() {
     setIsConfirmOpen(true);
   }
 
-  // 2. delete confirm: nach ConfirmModal Löschung
+  // 2. delete-confirm: nach ConfirmModal Löschung
   async function handleConfirmDelete() {
     try {
       const response = await fetch(`/api/transactions/${id}`, {
         method: "DELETE",
       });
 
-      if (!response.ok) throw new Error("Failed to delete transaction");
-
-      setIsConfirmOpen(false); // Modal schließen nach erfolgreichem delete
-
-      console.log("DELETING SUCCESSFUL! (transaction)!");
-
-      router.back(); // nach Löschen zurück zur vorherigen Seite
+      if (response.ok) {
+        console.log("DELETING SUCCESSFUL! (transaction)");
+        setIsConfirmOpen(false); //  Modal schließen
+        router.back(); // zurück zur vorherigen page
+      } else {
+        throw new Error(
+          `Failed to delete transaction (status: ${response.status})`
+        );
+      }
     } catch (error) {
       console.error("Error deleting transaction: ", error);
-      setIsConfirmOpen(false); // Modal bei error schließen, damit user nicht festhängt
+      setIsConfirmOpen(false); // Modal schließen, damit user nicht festhängt
     }
   }
 
@@ -115,7 +119,8 @@ export default function FormEditTransaction() {
                 id="income"
                 name="type"
                 value="Income"
-                checked={typeFromSelectedCategory === "Income"}
+                checked={currentType === "Income"}
+                readOnly // react warning (checked obwohl kein onChange)
                 required
               />
               <label htmlFor="income">Income</label>
@@ -127,7 +132,8 @@ export default function FormEditTransaction() {
                 id="expense"
                 name="type"
                 value="Expense"
-                checked={typeFromSelectedCategory === "Expense"}
+                checked={currentType === "Expense"}
+                readOnly // react warning (checked obwohl kein onChange)
               />
               <label htmlFor="expense">Expense</label>
             </RadioOption>
@@ -190,13 +196,13 @@ export default function FormEditTransaction() {
       </FormContainer>
 
       <ConfirmModal
-        open={isConfirmOpen} // Modal offen, wenn isConfirmOpen = true
+        open={isConfirmOpen} // immer aktueller state
         title="Delete transaction?"
         message="Are you sure you want to delete this transaction? This cannot be undone."
         confirmLabel="Delete"
         cancelLabel="Cancel"
-        onConfirm={handleConfirmDelete} // Löschung erst bei confirm
-        onCancel={() => setIsConfirmOpen(false)} // Modal schließen über Cancel / Overlay / ESC
+        onConfirm={handleConfirmDelete} // transaction löschen
+        onCancel={() => setIsConfirmOpen(false)} // schließen (Cancel / ESC / Overlay)
       />
     </PageWrapper>
   );

--- a/components/FormEditTransaction.js
+++ b/components/FormEditTransaction.js
@@ -82,7 +82,9 @@ export default function FormEditTransaction() {
         <h1>Edit Transaction</h1>
 
         <TypeGroup>
-          <label htmlFor="type">Type:</label>
+          <label htmlFor="type" className="label-type">
+            Type:
+          </label>
 
           <RadioRow>
             <RadioOption>
@@ -178,23 +180,22 @@ export default function FormEditTransaction() {
 }
 
 const PageWrapper = styled.div`
-  min-height: 100vh; // Wrapper nimmt mind. volle Bildschirmhöhe ein
-  display: flex; // zentriert Inhalt
-  justify-content: center; // form horizontal zentriert
-  align-items: center; // form vertikal zentriert
   padding: 2rem; // Abstand zum Bildschirmrand
+  min-height: 100vh; // wrapper mind. wie viewport
+  display: flex; // wegen Zentrierung von form
+  align-items: center; // form vertikal zentriert
+  justify-content: center; // form horizontal zentriert
 `;
 
 const FormContainer = styled.form`
-  width: 100%; // gesamte verf. Breite von Elterncontainer
-  max-width: 420px;
+  max-width: 300px;
   background-color: var(--button-background-color);
   padding: 1.5rem 2rem 2rem 2rem;
   border-radius: 1.5rem; // abgerundete Ecken
 
-  display: flex; // vertikale Anordnung von form-Inhalt
-  flex-direction: column; // untereinander
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.66);
+  display: flex; // content vertikal
+  flex-direction: column; // content untereinander
+  box-shadow: 0 0 20px rgba(0, 0, 0, 1);
 
   h1 {
     text-align: center;
@@ -206,77 +207,93 @@ const FormContainer = styled.form`
     margin-bottom: 0.5rem; // Abstand zw. label & jeweiligem input
   }
 
-  label:first-child {
-    margin-bottom: 0.8rem;
-
-    // bei Umbruch von Type & RadioRow kein margin-bottom -> TypeGroup margin-bottom zum nächsten Block
-    @media (max-width: 338px) {
-      margin-bottom: 0;
-    }
-  }
-
-  input,
-  select {
-    cursor: pointer;
+  select,
+  input[type="text"],
+  input[type="number"],
+  input[type="date"] {
     margin-bottom: 0.8rem; // Abstand zw. Blöcken
     border-radius: 0.5rem; // abgerundete Ecken
     border: 0.07rem solid var(--button-hover-color);
-  }
-
-  input[type="text"],
-  input[type="number"],
-  input[type="date"],
-  select {
     height: 1.5rem;
-    accent-color: var(
-      --button-hover-color
-    ); // Firefox: wenn Feld angeklickt, kein blauer Rahmen
+
+    // Firefox: wenn Feld angeklickt, kein blauer Rahmen:
+    accent-color: var(--button-hover-color);
   }
 
-  input:last-of-type {
+  select {
+    cursor: pointer;
+  }
+
+  input[type="date"] {
     margin-bottom: 0; // letztes input-Feld kein Abstand zu ButtonContainer
+    cursor: text;
   }
 `;
 
 const TypeGroup = styled.div`
   display: flex; // Type & RadioRow in einer Reihe
   flex-wrap: wrap; // Umbruch von Type & RadioRow, wenn nicht genug Platz
-  gap: 1rem; // Abstand zw. Type & RadioRow
+  margin-bottom: 1rem; // Abstand zu Category
 
-  // bei Umbruch von Type & RadioRow kleinere gap + margin-bottom zum nächsten Block
-  @media (max-width: 338px) {
-    gap: 0.35rem;
-    margin-bottom: 0.7rem;
+  // *** Abstand zw. Type & RadioRow: ***************************************
+  // margin, nicht margin-right! (im FormContainer haben label margin-bottom)
+  .label-type {
+    margin: 0 1rem 0 0;
+
+    @media (max-width: 338px) {
+      margin: 0 0.75rem 0 0; // kleiner
+    }
+    @media (max-width: 326px) {
+      margin: 0 0.75rem 0.35rem 0; // bei Umbruch auch unten
+    }
+  }
+  // ************************************************************************
+
+  @media (max-width: 326px) {
+    margin-bottom: 0.8rem; // Abstand zu Category bei Umbruch von Type & Radiorow
   }
 `;
 
 const RadioRow = styled.div`
   display: flex; // beide RadioOptions nebeneinander
-  gap: 1rem; // Abstand zw. RadioOptions
 
-  // bei Umbruch von Type & RadioRow kleinere gap
+  // *** Abstand zw. RadioOptions: *******************************************
+  gap: 1rem;
+
   @media (max-width: 338px) {
-    gap: 0.35rem;
+    gap: 0.5rem; // kleiner
   }
+  @media (max-width: 326px) {
+    gap: 1rem; // bei Umbruch von Type & Radiorow wieder normal
+  }
+  // **************************************************************************
 `;
 
 const RadioOption = styled.div`
   input {
-    accent-color: var(--button-hover-color);
+    cursor: pointer;
+    margin-right: 0.35rem; // Abstand zw. radio & label
+  }
+
+  input#income {
+    accent-color: var(--income-color);
+  }
+  input#expense {
+    accent-color: var(--expense-color);
   }
 
   label {
+    cursor: pointer;
     font-size: 0.9rem;
     font-weight: normal;
-    margin-left: 0.35rem; // Abstand zw. radio & label
   }
 `;
 
 const ButtonContainer = styled.div`
-  margin-top: 2rem; // Abstand zum letzten input-Feld
-  display: flex;
+  margin-top: 2rem; // Abstand zum letzten input
+  display: flex; // wegen Zentrierung
   justify-content: center; // buttons zentriert
-  gap: 1rem; // Abstand zw. buttons
+  gap: 0.8rem; // Abstand zw. buttons
   flex-wrap: wrap; // Umbruch; buttons untereinander
 
   button {
@@ -285,10 +302,11 @@ const ButtonContainer = styled.div`
     min-width: 70px;
     min-height: 30px;
     cursor: pointer;
+    font-weight: bold;
+    background-color: var(--secondary-text-color);
 
     &:hover {
       transform: scale(1.07);
-      font-weight: bold;
     }
   }
 `;

--- a/styles.js
+++ b/styles.js
@@ -47,7 +47,7 @@ export default createGlobalStyle`
   }
 
   h1 {
-    font-size: 2rem;
+    font-size: 1.85rem;
   }
 
   h2 {


### PR DESCRIPTION
- aligns styling between add & edit forms 
- improves type handling based on current category (transaction forms)
- cleans up code for better readability & maintainability (all forms)

add transaction form:
-  automatically updates type when category is selected
-  resets type to unselected when category selection is cleared
-  allows manual type selection only when no category is selected

edit transaction form:
-  automatically updates type when category is selected
-  disables manual type changes
