### PR TITLE
replace deprecated Mongoose update option

### DIFF
--- a/pages/api/categories/[id].js
+++ b/pages/api/categories/[id].js
@@ -74,7 +74,7 @@ export default async function handler(request, response) {
       const updatedCategory = await Category.findOneAndUpdate(
         { _id: categoryId, userId: dbUserId },
         fieldToUpdate,
-        { new: true, runValidators: true } // geupdatete category
+        { returnDocument: "after", runValidators: true } // geupdatete category
       );
 
       if (!updatedCategory) {

--- a/pages/api/transactions/[id].js
+++ b/pages/api/transactions/[id].js
@@ -65,7 +65,7 @@ export default async function handler(request, response) {
       const updatedTransaction = await Transaction.findOneAndUpdate(
         { _id: transactionId, userId: dbUserId },
         { category: categoryId, description, amount, date },
-        { new: true, runValidators: true } // geupdatete transaction
+        { returnDocument: "after", runValidators: true } // geupdatete transaction
       ).populate("category"); // mit category-object
 
       if (!updatedTransaction) {


### PR DESCRIPTION
- replaced deprecated `new` option with `returnDocument: "after"` in category + transaction updates
- preserved validation + updated document response behavior
- verified category + transaction editing without Mongoose warnings
- verified formatting, linting, + production build